### PR TITLE
Add ignore-scripts flag

### DIFF
--- a/browser-extension/api-server/.husky/pre-commit
+++ b/browser-extension/api-server/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-cd "browser extension/api-server"
+cd "browser-extension/api-server"
 npm run pre-commit

--- a/browser-extension/api-server/Dockerfile
+++ b/browser-extension/api-server/Dockerfile
@@ -3,9 +3,9 @@ WORKDIR /app
 
 COPY package.json /app/package.json
 RUN cd /app
-RUN npm install
-RUN npm install sequelize-cli
-RUN npm install -g nodemon
+RUN npm install --ignore-scripts
+RUN npm install sequelize-cli --ignore-scripts
+RUN npm install -g nodemon --ignore-scripts
 COPY ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
- Added ignore-scripts flag to api-server Dockerfile
- Fixed husky pre-commit folder name in api-server
- This fixes https://github.com/tattle-made/security/issues/20