### PR TITLE
fix: parcel giving 404 on localhost:1234

### DIFF
--- a/browser-extension/plugin/package.json
+++ b/browser-extension/plugin/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "prepare": "cd ../.. && husky install \"browser-extension/plugin/.husky\"",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "start:options": "parcel src/options.jsx",
+        "start:options": "parcel src/options.html",
         "start:contentScript": "parcel src/content-script.js",
         "moveBuildArtefactsToDistDir": "cp src/options.html dist && cp manifest.json dist && cp icon* dist && cp src/background.js dist",
         "moveBuildArtefactsToFirefoxDistDir": "cp src/options.html dist && cp manifest.firefox.json dist/manifest.json && cp icon* dist && cp src/background.js dist",

--- a/browser-extension/plugin/src/options.html
+++ b/browser-extension/plugin/src/options.html
@@ -28,6 +28,6 @@
     </head>
     <body>
         <div id="app"></div>
-        <script src="options.js"></script>
+        <script src="options.jsx" type="module"></script>
     </body>
 </html>


### PR DESCRIPTION
This PR fixes the error of `parcel` giving us a 404 error on localhost:1234

The front end of the browser extension can be just loaded using the `options.jsx` file in the `plugin/src` folder. 
The error occurring was when we tried to run just the frontend using the `npm run start:options`, which triggers this command `parcel src/options.jsx`

To fix it we have to actually run the `options.html` file using parcel, in which we pass the `options.jsx` file. 
now the frontend runs on `localhost:1234`