### PR TITLE
fix: re- parcel error 

### DIFF
--- a/browser-extension/plugin/package.json
+++ b/browser-extension/plugin/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "prepare": "cd ../.. && husky install \"browser-extension/plugin/.husky\"",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "start:options": "parcel src/options.html",
+        "start:options": "parcel src/options.jsx",
         "start:contentScript": "parcel src/content-script.js",
         "moveBuildArtefactsToDistDir": "cp src/options.html dist && cp manifest.json dist && cp icon* dist && cp src/background.js dist",
         "moveBuildArtefactsToFirefoxDistDir": "cp src/options.html dist && cp manifest.firefox.json dist/manifest.json && cp icon* dist && cp src/background.js dist",


### PR DESCRIPTION
We will have to go back to the original code of `npm run dev:options` as that is required to load the frontend in the browser extension. 