### PR TITLE
Harden dockerfile

### DIFF
--- a/browser-extension/api-server/.dockerignore
+++ b/browser-extension/api-server/.dockerignore
@@ -1,2 +1,7 @@
+.dockerignore
 node_modules
 npm-debug.log
+Dockerfile
+.git
+.gitignore
+.npmrc

--- a/browser-extension/api-server/Dockerfile
+++ b/browser-extension/api-server/Dockerfile
@@ -1,12 +1,13 @@
-FROM node:16-alpine
+FROM node:18.17.1-alpine3.18@sha256:3482a20c97e401b56ac50ba8920cc7b5b2022bfc6aa7d4e4c231755770cf892f
+ENV NODE_ENV production
 WORKDIR /app
 
-COPY package.json /app/package.json
+COPY --chown=node:node package.json /app/package.json
 RUN cd /app
 RUN npm install --ignore-scripts
 RUN npm install sequelize-cli --ignore-scripts
 RUN npm install -g nodemon --ignore-scripts
-COPY ./entrypoint.sh /
+COPY --chown=node:node ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 USER node
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
- Updated node alpine image version with explicit digest
- Optimized node tooling for production
- Changed ownership of copied files
- Updated .dockerignore
- This addresses https://github.com/tattle-made/security/issues/26