### PR TITLE
fix: undefined is being added to Slur list when added using right click

### DIFF
--- a/browser-extension/plugin/src/content-script.js
+++ b/browser-extension/plugin/src/content-script.js
@@ -96,20 +96,17 @@ chrome.runtime.onMessage.addListener(async function (request) {
         log('slur added from bg', slur);
         const pref = await getPreferenceData();
         let slurList;
-        if (!pref) {
+        if (!pref || !pref.slurList) {
             slurList = slur;
-            await setPreferenceData({ ...pref, slurList });
         } else {
-            // let { slurList } = pref;
             slurList = pref.slurList;
             if (!slurList || slurList === '') {
-                slurList += slur;
+                slurList = slur;
             } else {
                 slurList += `,${slur}`;
             }
-            await setPreferenceData({ ...pref, slurList });
         }
-
+        await setPreferenceData({ ...pref, slurList });
         return true;
     }
     if (request.type === 'ULI_ENABLE_TOGGLE') {


### PR DESCRIPTION
## **Describe the PR**
When a user login's to Uli for the first time and add a word to the `Slur List` in `prefrences`. The word `undefined` is also added in front of the word. For instance, if I want to select right click and add the word `measure` to my `slur list`, then right now its being getting added like this


![Screenshot 2023-10-03 17:26:18](https://github.com/tattle-made/Uli/assets/56875084/0492a4c0-c093-4a1c-8d17-d20d96bee537)

## **Fixing this Issue**
1. Modified the logic in the `content-script.js` file to handle the slur addition
2. Previously, when the preference data (`pref`) was not defined, the code attempted to spread `undefined` values into the new object when updating slurList. This occurs when the user activates the account and just tries to add a slur word. I fixed this by checking if `pref` or `pref.slurList` is `undefined` and directly assigning the value of the slur to `slurList`


## **To Test and Review this PR**
@dennyabrain just to make sure its not some issue on my machine, 
The review could 
1. just test the current state of the right-click add word feature - note, it is important to check this feature right after activating the account. 
3. And then, one could pull my PR and test if the issue is being resolved or not. 

I have tested it out on my end by just adding multiple slur words to the list back to back using the right click feature, and they were getting blurred by Uli. 