### PR TITLE
Harden dockerfile

### DIFF
--- a/browser-extension/api-server/Dockerfile
+++ b/browser-extension/api-server/Dockerfile
@@ -7,7 +7,7 @@ RUN cd /app
 RUN npm install --ignore-scripts
 RUN npm install sequelize-cli --ignore-scripts
 RUN npm install -g nodemon --ignore-scripts
-COPY . .
+COPY --chown=node:node . .
 COPY --chown=node:node ./entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 USER node


### PR DESCRIPTION
- Changed ownership from root to node for recursive copy command
This fixes issue: https://github.com/tattle-made/security/issues/34