### PR TITLE
refactor: changing permission for url in manifest

### DIFF
--- a/browser-extension/plugin/manifest.json
+++ b/browser-extension/plugin/manifest.json
@@ -7,11 +7,8 @@
     "content_security_policy": {
         "extension_pages": "default-src 'none'; connect-src https://ogbv-plugin.tattle.co.in/ https://uli-media.tattle.co.in/; font-src https://fonts.gstatic.com; object-src 'none'; script-src 'self'; style-src https://fonts.googleapis.com 'self' 'unsafe-inline'; img-src https://uli-media.tattle.co.in/; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; report-uri 'none';"
     },
-    "permissions": [
-        "storage",
-        "contextMenus",
-        "https://ogbv-plugin.tattle.co.in/*"
-    ],
+    "permissions": ["storage", "contextMenus"],
+    "host_permissions": ["https://ogbv-plugin.tattle.co.in/*"],
     "background": {
         "service_worker": "background.js"
     },


### PR DESCRIPTION
This PR changes how we add permissions to the `manifest.json` file.

@duggalsu pointed out that Manifest v3 does not recommend adding URL's to `permissions`, instead they suggest we add URL's to `host_permissions` 
`host_permissions` - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions

I have made this change for `manifest.json` and tested out in chromium based browsers. I have not made this change for firefox as it still uses manifest v2

@dennyabrain you can review this at your time of comfort and then merge it