### PR TITLE
feat: add slur and crowdsource slur on one click && feat: loading bar for slur crowdsource

### DIFF
--- a/browser-extension/plugin/src/background.js
+++ b/browser-extension/plugin/src/background.js
@@ -42,16 +42,6 @@ contextMenus.create(
         console.log('context menu created');
     }
 );
-contextMenus.create(
-    {
-        id: 'add-crowdsource-slur',
-        title: 'Crowdsource Slur Word',
-        contexts: ['selection']
-    },
-    () => {
-        console.log('crowdsource context menu created');
-    }
-);
 
 contextMenus.onClicked.addListener(async (info, tab) => {
     switch (info.menuItemId) {
@@ -60,19 +50,6 @@ contextMenus.onClicked.addListener(async (info, tab) => {
             tabs.sendMessage(
                 tab.id,
                 { type: 'SLUR_ADDED', slur: info.selectionText },
-                function (response) {
-                    console.log(response);
-                }
-            );
-            break;
-        case 'add-crowdsource-slur':
-            console.log('Crowdsource slur word added');
-            tabs.sendMessage(
-                tab.id,
-                {
-                    type: 'CROWDSOURCE_SLUR_WORD',
-                    crowdsourcedSlur: info.selectionText
-                },
                 function (response) {
                     console.log(response);
                 }

--- a/browser-extension/plugin/src/content-script.js
+++ b/browser-extension/plugin/src/content-script.js
@@ -100,6 +100,15 @@ chrome.runtime.onMessage.addListener(async function (request) {
         log('slur added from bg', slur);
         const pref = await getPreferenceData();
         let slurList;
+
+        const user = await getUserData();
+        // console.log('USER in content-script', user);
+        const crowdsourceData = {
+            label: slur,
+            categories: []
+        };
+
+        // Adding Slur to Prefrences
         if (!pref || !pref.slurList) {
             slurList = slur;
         } else {
@@ -110,27 +119,22 @@ chrome.runtime.onMessage.addListener(async function (request) {
                 slurList += `,${slur}`;
             }
         }
-        await setPreferenceData({ ...pref, slurList });
-        return true;
-    }
-    if (request.type === 'CROWDSOURCE_SLUR_WORD') {
-        const crowdsource_slur = request.crowdsourcedSlur;
-        console.log('crowdsourced slur from bg = ', crowdsource_slur);
-        const user = await getUserData();
-        console.log('USER in cotnent', user);
-        const crowdsourceData = {
-            label: crowdsource_slur,
-            categories: []
-        };
+        try {
+            await setPreferenceData({ ...pref, slurList });
+        } catch (error) {
+            console.error('error updating pref data', error);
+        }
+
+        //Crowdsourcing Slur
         try {
             await createSlurAndCategory(user.accessToken, crowdsourceData);
             console.log('finsihed POST req');
-            window.alert(
-                `Crowdsourced Slur "${crowdsource_slur}" added to Uli`
-            );
+            window.alert(`Slur word "${slur}" added to Uli`);
         } catch (error) {
             console.log(error);
         }
+
+        return true;
     }
 
     if (request.type === 'ULI_ENABLE_SLUR_REPLACEMENT') {

--- a/browser-extension/plugin/src/ui-components/pages/Slur.jsx
+++ b/browser-extension/plugin/src/ui-components/pages/Slur.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useContext } from 'react';
-import { Box, Text, Button } from 'grommet';
+import { Box, Text, Button, Spinner } from 'grommet';
 import { Add, Edit, Trash } from 'grommet-icons';
 import { useNavigate } from 'react-router-dom';
 import Api from './Api';
 import { UserContext, NotificationContext } from '../atoms/AppContext';
 import SlurCard from '../atoms/SlurCard';
-import SlurCardComponent from '../atoms/SlurCardComponent';
+// import SlurCardComponent from '../atoms/SlurCardComponent';
 
 const { getSlurAndCategory, deleteSlurAndCategory } = Api;
 
@@ -14,18 +14,24 @@ export function Slur() {
     const [getSlurs, setGetSlurs] = useState([]);
     const { user } = useContext(UserContext);
     const { showNotification } = useContext(NotificationContext);
+    const [isLoading, setIsLoading] = useState(true);
 
     const navigateToAddSlur = () => {
         navigate('/slur/create');
     };
     async function fetchSlurs() {
+        setIsLoading(true);
         try {
+            // adding delay for development server testing
+            // await new Promise(resolve => setTimeout(resolve, 500));
             const slur = await getSlurAndCategory(user.accessToken);
             slur.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
             setGetSlurs(slur);
             console.log(slur);
         } catch (error) {
             console.error('error fetching slurs', error);
+        } finally {
+            setIsLoading(false);
         }
     }
     async function handleDeleteSlur(slurId) {
@@ -52,7 +58,11 @@ export function Slur() {
     return (
         <Box fill gap={'medium'}>
             <Box gap="medium" alignContent="center" wrap>
-                {getSlurs.length === 0 ? (
+                {isLoading ? (
+                    <Box alignContent="center">
+                        <Spinner margin="xlarge" size="medium" />
+                    </Box>
+                ) : getSlurs.length === 0 ? (
                     <>
                         <Box alignContent="center">
                             <Text textAlign="center">
@@ -110,7 +120,7 @@ export function Slur() {
                             <Box
                                 key={index}
                                 // background="#fbeeac"
-                                background={"#FFE5B4"}
+                                background={'#FFE5B4'}
                                 pad="medium"
                                 round="medium"
                                 width="medium"
@@ -141,7 +151,7 @@ export function Slur() {
                                             <Button
                                                 id="slur-edit-button"
                                                 // label="Edit"
-                                                icon={<Edit size="medium"/>}
+                                                icon={<Edit size="medium" />}
                                                 onClick={() =>
                                                     navigate(`/slur/${slur.id}`)
                                                 }
@@ -156,7 +166,12 @@ export function Slur() {
                                             <Button
                                                 id="slur-delete-button"
                                                 // label="Delete"
-                                                icon={<Trash size='medium' color='#C60000'/>}
+                                                icon={
+                                                    <Trash
+                                                        size="medium"
+                                                        color="#C60000"
+                                                    />
+                                                }
                                                 onClick={() =>
                                                     handleDeleteSlur(slur.id)
                                                 }


### PR DESCRIPTION
This PR add two things
1. it resolves this issue - https://github.com/tattle-made/Uli/issues/423. Users can right click add a slur word to Uli, that word will be added to their `personal slur list` and also it will be `crowdsourced`.
2. I have added a loading bar to the `slur crowdsource` feature, as I noticed it takes a small fraction of a second in production for fetching slurs.

@dennyabrain can you review this PR and merge it. 
I have tested this PR on firefox, chrome and brave, things are working perfectly fine on my end. 