### PR TITLE
chore: Improve UI of Add Slur form

### DIFF
--- a/browser-extension/plugin/src/ui-components/pages/SlurCreate.jsx
+++ b/browser-extension/plugin/src/ui-components/pages/SlurCreate.jsx
@@ -156,6 +156,8 @@ export function SlurCreate() {
                     <TextArea
                         id="slur-form-label-meaning"
                         name="labelMeaning"
+                        focusIndicator="true"
+                        resize="vertical"
                     />
                 </FormField>
 


### PR DESCRIPTION
---
name: small patch
about: Improve UI of Add Slur form
labels: enhancement

---

Relates to #409 

**Describe the PR**

It's a small patch that adds a border to the *"What makes it problematic?"* text area and restricts reszing to only vertical.

**Before:** At first glance itself, the cursor feels like in a odd poisiton in the text area with a lot of gap between the border below. Allowing horizontal scroll makes it messier

https://github.com/tattle-made/Uli/assets/130062020/713da799-2a92-4a27-b217-057b2da8c3ed

After:

https://github.com/tattle-made/Uli/assets/130062020/49f76c92-c583-4970-a625-e7d70fe272cb
