### PR TITLE
chore: style text-area in `SlurEdit` to be consistent with `SlurCreate`

### DIFF
--- a/browser-extension/plugin/src/ui-components/pages/SlurEdit.jsx
+++ b/browser-extension/plugin/src/ui-components/pages/SlurEdit.jsx
@@ -172,6 +172,8 @@ export function SlurEdit() {
                     <TextArea
                         id="slur-form-label-meaning"
                         name="labelMeaning"
+                        focusIndicator="true"
+                        resize="vertical"
                     />
                 </FormField>
 


### PR DESCRIPTION
---
name: Chore
about: style text-area in `SlurEdit` to be consistent with `SlurCreate`
labels: follow-up

---

**Describe the PR**

Follow up PR for #550 

**Screenshots**

![image](https://github.com/tattle-made/Uli/assets/130062020/1907a69b-c0a6-4562-be02-a3b1a8beb669)
