### PR TITLE
Fix for #557: Order blogs in descending order of date

### DIFF
--- a/uli-website/src/pages/blog/approach.mdx
+++ b/uli-website/src/pages/blog/approach.mdx
@@ -3,7 +3,7 @@ name: "Thinking about Feminist Approaches to Technology"
 excerpt: " "
 author: "CIS and Tattle"
 project: " "
-date: 01-08-2021
+date: 2021-08-01
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/chisel-online-abuse.mdx
+++ b/uli-website/src/pages/blog/chisel-online-abuse.mdx
@@ -3,7 +3,7 @@ name: Designing a Tool to Chisel Away at Online Abuse
 excerpt: "Is it possible to imbue the creation of a #machinelearning tool with principles? That was our intent with Uli."
 author: "Tattle"
 project: 
-date: 02-05-2024
+date: 2024-05-02
 tags: 
 ---
 

--- a/uli-website/src/pages/blog/cross-platform-pt1.mdx
+++ b/uli-website/src/pages/blog/cross-platform-pt1.mdx
@@ -3,7 +3,7 @@ name: "A Side of Whack-A-Mole (Part 1)"
 excerpt: " "
 author: "Kaustubha"
 project: " "
-date: 13-03-2024
+date: 2024-03-13
 ---
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"
 

--- a/uli-website/src/pages/blog/cross-platform_pt_2.mdx
+++ b/uli-website/src/pages/blog/cross-platform_pt_2.mdx
@@ -3,7 +3,7 @@ name: "Another Side of Whack-A-Mole"
 excerpt: "We make a case for what federated and centralised platforms must implement in order to tackle cross-platform abuse more effectively "
 author: "Kaustubha"
 project: " "
-date: 17-04-2024
+date: 2024-04-17
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/getting-started-with-aws-copilot.mdx
+++ b/uli-website/src/pages/blog/getting-started-with-aws-copilot.mdx
@@ -3,7 +3,7 @@ name: Getting started with AWS CoPilot for Uli
 excerpt:
 author: Bhargav Dave
 project:
-date: 28-08-2022
+date: 2022-08-28
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/making-of-August-2023.mdx
+++ b/uli-website/src/pages/blog/making-of-August-2023.mdx
@@ -3,7 +3,7 @@ name: "Making of Uli: August 2023 Newsletter"
 excerpt: " "
 author: "Uli Team"
 project: " "
-date: 07-09-2023
+date: 2023-09-07
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/making-of-dec-2021.mdx
+++ b/uli-website/src/pages/blog/making-of-dec-2021.mdx
@@ -3,7 +3,7 @@ name: "Making of Uli: December 2021 Newsletter"
 excerpt: " "
 author: "CIS and Tattle"
 project: " "
-date: 15-12-2021
+date: 2021-12-15
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/making-of-dec-2023.mdx
+++ b/uli-website/src/pages/blog/making-of-dec-2023.mdx
@@ -3,7 +3,7 @@ name: "Making of Uli: November/December 2023 Newsletter"
 excerpt: " "
 author: "Uli Team"
 project: " "
-date: 22-12-2023
+date: 2023-12-22
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/making-of-feb-2022.mdx
+++ b/uli-website/src/pages/blog/making-of-feb-2022.mdx
@@ -3,7 +3,7 @@ name: "Making of Uli: February 2022 Newsletter"
 excerpt: " "
 author: "CIS and Tattle"
 project: " "
-date: 15-02-2022
+date: 2022-02-15
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/making-of-jan-2022.mdx
+++ b/uli-website/src/pages/blog/making-of-jan-2022.mdx
@@ -3,7 +3,7 @@ name: "Making of Uli: January 2022 Newsletter"
 excerpt: " "
 author: "CIS and Tattle"
 project: " "
-date: 15-01-2022
+date: 2022-01-15
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/making-of-mar-2022.mdx
+++ b/uli-website/src/pages/blog/making-of-mar-2022.mdx
@@ -3,7 +3,7 @@ name: "Making of Uli: March 2022 Newsletter"
 excerpt: " "
 author: "CIS and Tattle"
 project: " "
-date: 26-04-2022
+date: 2022-04-26
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/responsible-display.mdx
+++ b/uli-website/src/pages/blog/responsible-display.mdx
@@ -3,7 +3,7 @@ name: Responsible Way of Showcasing the Countering of OGBV
 excerpt:
 author: Yash Budhwar
 project:
-date: 16-04-2022
+date: 2022-04-16
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/silencing-impact-OGBV.mdx
+++ b/uli-website/src/pages/blog/silencing-impact-OGBV.mdx
@@ -3,7 +3,7 @@ name: "The Silencing Impact of Online Gender Based Violence"
 excerpt: "The fatigue caused by online gender-based violence often has a chilling effect. It silences diverse voices in the very spaces that need to be more equitable and inclusive!"
 author: "Kaustubha"
 project:
-date: 24-04-2024
+date: 2024-04-24
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/tech4dev-user-research-lessons.mdx
+++ b/uli-website/src/pages/blog/tech4dev-user-research-lessons.mdx
@@ -3,7 +3,7 @@ name: Lessons in User Research from Donald Lobo
 excerpt:
 author: Tarunima Prabhakar
 project:
-date: 18-04-2022
+date: 2022-04-18
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"

--- a/uli-website/src/pages/blog/uli-privacy.mdx
+++ b/uli-website/src/pages/blog/uli-privacy.mdx
@@ -3,7 +3,7 @@ name: Privacy Preserving Features of Uli
 excerpt:
 author: Denny George and Sudeep Duggal
 project:
-date: 15-07-2022
+date: 2022-07-15
 ---
 
 import ContentPageShell from "../../components/molecules/ContentPageShell.jsx"


### PR DESCRIPTION
---
name: [uli-website]: order blogs in descending order of date #557
about: order blogs in descending order of date
---

**Describe the PR**
This PR improves the order blogs in descending order of date.
Related to Issue https://github.com/tattle-made/Uli/issues/557.
Graphql query is right just needed to change date format of the Blog md files for sorting to be applicable.
