### PR TITLE
Create pie chart using Elixir map data

### DIFF
--- a/uli-community/assets/js/app.js
+++ b/uli-community/assets/js/app.js
@@ -57,8 +57,11 @@ window.addEventListener("phx:copy", (event) => {
   });
 });
 
-import { drawPieChart } from "./pie_chart";
 
-window.addEventListener("DOMContentLoaded", () => {
-  drawPieChart();
+import { drawPieChart } from "./pie_chart.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  drawPieChart(window.pieChartData);
 });
+
+

--- a/uli-community/assets/js/pie_chart.js
+++ b/uli-community/assets/js/pie_chart.js
@@ -1,58 +1,45 @@
 import * as d3 from "d3";
 
-// Exported function
-export function drawPieChart() {
-    // Dummy data for pie chart
-    const data = [
-        { label: "RED", value: 40 },
-        { label: "Blue", value: 25 },
-        { label: "Yellow", value: 35 },
-        { label: "Pink", value: 20 },
-        { label: "Green", value: 60 },
-        { label: "Black", value: 70 },
-        { label: "Purple", value: 90 },
-        { label: "Orange", value: 120 }
-    ];
+export function drawPieChart(data) {
+  if (!data || data.length === 0) return;
+  d3.select("#pie-chart").select("svg").remove();
 
-    // Size and radius
-    const width = 600;
-    const height = 600;
-    const radius = width / 2;
+  const width = 600;
+  const height = 600;
+  const radius = width / 2;
 
-    // Create SVG container
-    const svg = d3.select("#pie-chart")
-        .append("svg")
-        .attr("width", width)
-        .attr("height", height)
-        .append("g")
-        .attr("transform", `translate(${width / 2}, ${height / 2})`);
+  const svg = d3.select("#pie-chart")
+    .append("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .append("g")
+    .attr("transform", `translate(${width / 2}, ${height / 2})`);
 
-    // Color scale
-    const color = d3.scaleOrdinal()
-        .domain(data.map(d => d.label))
-        .range(["#ff9999", "#99ccff", "#ffff99", "#ffb6c1", "#b2d8b2", "#d9d9d9", "#d1b3ff", "#ffd699"]);
+  const color = d3.scaleOrdinal()
+    .domain(data.map(d => d.label))
+    .range([
+      "#ff9999", "#99ccff", "#ffff99", "#ffb6c1",
+      "#b2d8b2", "#d9d9d9", "#d1b3ff", "#ffd699"
+    ]);
 
-    // Create pie layout and arcs
-    const pie = d3.pie().value(d => d.value);
-    const arc = d3.arc().innerRadius(0).outerRadius(radius);
+  const pie = d3.pie().value(d => d.value);
+  const arc = d3.arc().innerRadius(0).outerRadius(radius);
 
-    // Draw pie chart slices
-    svg.selectAll("path")
-        .data(pie(data))
-        .enter()
-        .append("path")
-        .attr("d", arc)
-        .attr("fill", d => color(d.data.label))
-        .attr("stroke", "white")
-        .style("stroke-width", "2px");
+  svg.selectAll("path")
+    .data(pie(data))
+    .enter()
+    .append("path")
+    .attr("d", arc)
+    .attr("fill", d => color(d.data.label))
+    .attr("stroke", "white")
+    .style("stroke-width", "2px");
 
-    // Add labels to slices
-    svg.selectAll("text")
-        .data(pie(data))
-        .enter()
-        .append("text")
-        .text(d => d.data.label)
-        .attr("transform", d => `translate(${arc.centroid(d)})`)
-        .style("text-anchor", "middle")
-        .style("font-size", "14px");
+  svg.selectAll("text")
+    .data(pie(data))
+    .enter()
+    .append("text")
+    .text(d => d.data.label)
+    .attr("transform", d => `translate(${arc.centroid(d)})`)
+    .style("text-anchor", "middle")
+    .style("font-size", "14px");
 }

--- a/uli-community/lib/uli_community_web/controllers/dashboard_controller.ex
+++ b/uli-community/lib/uli_community_web/controllers/dashboard_controller.ex
@@ -2,6 +2,17 @@ defmodule UliCommunityWeb.DashboardController do
   use UliCommunityWeb, :controller
 
   def index(conn, _params) do
-    render(conn, :index, layout: false)
+    pie_data = [
+      %{label: "RED", value: 40},
+      %{label: "Blue", value: 25},
+      %{label: "Yellow", value: 35},
+      %{label: "Pink", value: 20},
+      %{label: "Green", value: 60},
+      %{label: "Black", value: 70},
+      %{label: "Purple", value: 90},
+      %{label: "Orange", value: 120}
+    ]
+
+    render(conn, :index, pie_data: pie_data, layout: false)
   end
 end

--- a/uli-community/lib/uli_community_web/controllers/dashboard_html/index.html.heex
+++ b/uli-community/lib/uli_community_web/controllers/dashboard_html/index.html.heex
@@ -3,3 +3,9 @@
   
   <div id="pie-chart" phx-update="ignore" class="inline-block"></div>
 </div>
+
+<script>
+  window.pieChartData = <%= raw Jason.encode!(@pie_data) %>;
+</script>
+
+<script src="/assets/app.js"></script>


### PR DESCRIPTION
### Description:
This PR adds a simple pie chart on the dashboard page using data from the Elixir backend.

- Converted an Elixir map into **JSON** and passed it to JavaScript using a `<script>` tag.
- Rendered the pie chart using **D3.js** by accessing the` window.pieChartData`.
- Ensured LiveView doesn't interfere with the chart rendering using `phx-update="ignore"`.
- Added logic to prevent duplicate SVGs when the chart reloads.

This resolves issue [#769](https://github.com/tattle-made/Uli/issues/769).

 ### Screenshot:
 
 
![Screenshot from 2025-05-22 13-47-52](https://github.com/user-attachments/assets/740a143c-88fc-4cd2-bcd6-0777bd078b91)
