### PR TITLE
feat: add pie chart visualization for top 5 crowdsourced slurs

### DIFF
--- a/uli-community/assets/js/pie_chart.js
+++ b/uli-community/assets/js/pie_chart.js
@@ -25,7 +25,7 @@ export function drawPieChart() {
       "#b2d8b2", "#d9d9d9", "#d1b3ff", "#ffd699"
     ]);
 
-  const pie = d3.pie().value(d => d.value);
+  const pie = d3.pie().value(d => d.count);
   const arc = d3.arc().innerRadius(0).outerRadius(radius);
 
   svg.selectAll("path")

--- a/uli-community/lib/uli_community/user_contribution.ex
+++ b/uli-community/lib/uli_community/user_contribution.ex
@@ -128,4 +128,14 @@ defmodule UliCommunity.UserContribution do
 
     {:ok, slurs}
   end
+
+  def get_top_5_slurs do
+  CrowdsourcedSlur
+  |> group_by([s], s.label)
+  |> select([s], %{label: s.label, count: count(s.id)})
+  |> order_by([s], desc: count(s.id))
+  |> limit(5)
+  |> Repo.all()
+end
+
 end

--- a/uli-community/lib/uli_community_web/controllers/dashboard_controller.ex
+++ b/uli-community/lib/uli_community_web/controllers/dashboard_controller.ex
@@ -2,17 +2,7 @@ defmodule UliCommunityWeb.DashboardController do
   use UliCommunityWeb, :controller
 
   def index(conn, _params) do
-    pie_data = [
-      %{label: "RED", value: 40},
-      %{label: "Blue", value: 25},
-      %{label: "Yellow", value: 35},
-      %{label: "Pink", value: 20},
-      %{label: "Green", value: 60},
-      %{label: "Black", value: 70},
-      %{label: "Purple", value: 90},
-      %{label: "Orange", value: 20}
-    ]
-
-    render(conn, :index, pie_data: pie_data, layout: false)
+    pie_data = UliCommunity.UserContribution.get_top_5_slurs()
+    render(conn, :index, pie_data: pie_data)
   end
 end

--- a/uli-community/priv/repo/seeds.exs
+++ b/uli-community/priv/repo/seeds.exs
@@ -9,3 +9,14 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias UliCommunity.UserContribution
+
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur1", page_url: "https://example.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur2", page_url: "https://test.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur1", page_url: "https://again.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur3", page_url: "https://third.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur2", page_url: "https://repeat.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur4", page_url: "https://more.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur5", page_url: "https://fifth.com"})
+UserContribution.create_crowdsourced_slur_seed(%{label: "slur1", page_url: "https://againagain.com"})


### PR DESCRIPTION
### Overview

This PR adds a pie chart visualization to the dashboard that displays the top 5 most frequently reported crowdsourced slurs. 
### What’s Included

- **Seed Script for Testing**  
  Added dummy data using `UserContribution.create_crowdsourced_slur_seed/1` in `priv/repo/seeds.exs` to test the chart effectively.

- **Top 5 Slurs Function**  
  Implemented `get_top_5_slurs/0` in the `UserContribution` module. It:
  - Groups slurs by label
  - Counts their frequency
  - Sorts them in descending order
  - Returns the top 5 in `%{label, count}` format

- **Dashboard Integration**
  - Called `get_top_5_slurs/0` from `DashboardController`
  - Assigned the result to `@pie_data`

- **Frontend Integration**
  - Embedded `@pie_data` in the `dashboard.html.heex` template using `Jason.encode!`
  - Rendered a pie chart using JavaScript (with either D3.js or native SVG)
  - Automatically draws the chart on `DOMContentLoaded`

### Related Issue

Fixes [#777](https://github.com/tattle-made/Uli/issues/777)

**Sreenshot :-**
![Screenshot from 2025-05-29 15-12-55](https://github.com/user-attachments/assets/621fed0b-56a2-4719-9b2b-28f051f16328)
