### PR TITLE
Add bar chart on /dashboard to show top 10 contributed slurs using D3.js

### DIFF
--- a/uli-community/assets/js/app.js
+++ b/uli-community/assets/js/app.js
@@ -23,6 +23,7 @@ import { LiveSocket } from "phoenix_live_view";
 import topbar from "../vendor/topbar";
 import { drawPieChart } from "./pie_chart.js";
 import { PieChartHook } from "./hooks/pie_chart_hook";
+import { BarChartHook } from "./hooks/bar_chart_hook.js";
 
 
 
@@ -32,6 +33,7 @@ let csrfToken = document
 
 let Hooks = {};
 Hooks.PieChartHook = PieChartHook;
+Hooks.BarChartHook = BarChartHook
 
 let liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,

--- a/uli-community/assets/js/bar_chart.js
+++ b/uli-community/assets/js/bar_chart.js
@@ -1,0 +1,56 @@
+import * as d3 from "d3";
+
+export function drawBarChart() {
+  const container = document.querySelector("#bar-chart");
+  const data = JSON.parse(container.dataset.bar);
+
+  if (!data || data.length === 0) return;
+  d3.select("#bar-chart").select("svg").remove();
+
+  const margin = { top: 20, right: 30, bottom: 50, left: 120 };
+  const width = 700 - margin.left - margin.right;
+  const height = 400 - margin.top - margin.bottom;
+
+  const svg = d3.select("#bar-chart")
+    .append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+    .attr("transform", `translate(${margin.left},${margin.top})`);
+
+  const x = d3.scaleLinear()
+    .domain([0, d3.max(data, d => d.count)])
+    .range([0, width])
+    .nice();
+
+  const y = d3.scaleBand()
+    .domain(data.map(d => d.label))
+    .range([0, height])
+    .padding(0.2);
+
+  svg.append("g").call(d3.axisLeft(y));
+  svg.append("g")
+    .attr("transform", `translate(0, ${height})`)
+    .call(d3.axisBottom(x));
+
+  svg.selectAll("rect")
+    .data(data)
+    .enter()
+    .append("rect")
+    .attr("y", d => y(d.label))
+    .attr("x", 0)
+    .attr("height", y.bandwidth())
+    .attr("width", d => x(d.count))
+    .attr("fill", "#252653");
+
+  svg.selectAll("text.bar-label")
+    .data(data)
+    .enter()
+    .append("text")
+    .attr("class", "bar-label")
+    .attr("x", d => x(d.count) - 5)
+    .attr("y", d => y(d.label) + y.bandwidth() / 2 + 4)
+    .attr("text-anchor", "end")
+    .style("fill", "white")
+    .text(d => d.count);
+}

--- a/uli-community/assets/js/hooks/bar_chart_hook.js
+++ b/uli-community/assets/js/hooks/bar_chart_hook.js
@@ -1,0 +1,10 @@
+import { drawBarChart } from "../bar_chart";
+
+export const BarChartHook = {
+  mounted() {
+    drawBarChart();
+  },
+  updated() {
+    drawBarChart();
+  }
+};

--- a/uli-community/lib/uli_community_web/live/dashboard_live.ex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.ex
@@ -6,12 +6,12 @@ defmodule UliCommunityWeb.DashboardLive do
 
   def mount(_params, _session, socket) do
     if connected?(socket), do: Phoenix.PubSub.subscribe(UliCommunity.PubSub, @topic)
-    slurs = UserContribution.get_top_slurs(5)
+    slurs = UserContribution.get_top_slurs(10)
     {:ok, assign(socket, slurs: slurs)}
   end
 
   def handle_info(:slur_changed, socket) do
-    slurs = UserContribution.get_top_slurs(5)
+    slurs = UserContribution.get_top_slurs(10)
     {:noreply, assign(socket, slurs: slurs)}
   end
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
@@ -1,9 +1,8 @@
 <div class="p-4">
-  <h2 class="text-xl font-bold mb-4">Dashboard</h2>
-
-  <div id="pie-chart"
-       phx-hook="PieChartHook"
-       data-pie={Jason.encode!(@slurs)}
-       class="w-full h-96">
-  </div>
+     <h2 class="text-xl font-bold mb-4">Dashboard</h2>
+     <div id="bar-chart"
+          phx-hook="BarChartHook"
+          data-bar={Jason.encode!(@slurs)}
+          class="w-full h-96 mt-10">
+     </div>
 </div>


### PR DESCRIPTION

### Description:-
This pull request adds a bar chart to the` /dashboard` page to display the top 10 most frequently contributed slurs from the `crowdsourced_slurs` table, as described in [Issue #788](https://github.com/tattle-made/Uli/issues/788).
The bar chart is implemented using **D3.js** and rendered via a LiveView hook. Each bar represents a slur, and the length of the bar corresponds to its contribution count. The values are displayed as labels inside each bar for better readability.

**Key Implementation Details :-**

- A new hook `BarChartHook` was added to render the chart when the LiveView is mounted or updated.
- The chart is rendered inside a div with the `phx-hook="BarChartHook"` and receives its data via `data-bar,` encoded in JSON from the LiveView assigns.
- Styling is applied using TailwindCSS, and the chart is displayed with a consistent dark theme (`#252653`).
- The backend uses the existing `get_top_slurs/1` context method to fetch the top 10 slurs.
- The layout ensures the chart is cleanly embedded and does not conflict with other dashboard components.

This enhancement provides a more visual understanding of frequently reported slurs and improves the dashboard's data representation.

**Screenshot :-** 
![Screenshot from 2025-06-12 21-01-09](https://github.com/user-attachments/assets/18f5a1a7-a69b-427a-8605-23a4b78ab782)
