### PR TITLE
Add pie chart to visualize slur distribution by severity using D3.js

### DIFF
--- a/uli-community/assets/js/pie_chart.js
+++ b/uli-community/assets/js/pie_chart.js
@@ -2,9 +2,15 @@ import * as d3 from "d3";
 
 export function drawPieChart() {
   const container = document.querySelector("#pie-chart");
-  const data = JSON.parse(container.dataset.pie)
+  if (!container || !container.dataset.severity) return;
+
+  let data = JSON.parse(container.dataset.severity);
+
+  // Filter out invalid/empty labels
+  data = data.filter(d => d.label && d.label.trim() !== "");
 
   if (!data || data.length === 0) return;
+
   d3.select("#pie-chart").select("svg").remove();
 
   const width = 600;
@@ -18,12 +24,10 @@ export function drawPieChart() {
     .append("g")
     .attr("transform", `translate(${width / 2}, ${height / 2})`);
 
+  // Color mapping based on severity level
   const color = d3.scaleOrdinal()
-    .domain(data.map(d => d.label))
-    .range([
-      "#ff9999", "#99ccff", "#ffff99", "#ffb6c1",
-      "#b2d8b2", "#d9d9d9", "#d1b3ff", "#ffd699"
-    ]);
+    .domain(["low", "medium", "high"])
+    .range(["#FCBFA4", "#F4C6D7", "#F39695"]); 
 
   const pie = d3.pie().value(d => d.count);
   const arc = d3.arc().innerRadius(0).outerRadius(radius);
@@ -33,33 +37,30 @@ export function drawPieChart() {
     .enter()
     .append("path")
     .attr("d", arc)
-    .attr("fill", d => color(d.data.label))
+    .attr("fill", d => color(d.data.label) || "#cccccc") // fallback color
     .attr("stroke", "white")
     .style("stroke-width", "2px");
 
   svg.selectAll("text")
-  .data(pie(data))
-  .enter()
-  .append("text")
-  .attr("transform", d => `translate(${arc.centroid(d)})`)
-  .style("text-anchor", "middle")
-  .style("font-size", "14px")
-  .style("fill", "#333")
-  .each(function(d) {
-    const text = d3.select(this);
-    
-    // Line 1: Label
-    text.append("tspan")
-      .attr("x", 0)
-      .attr("dy", "0em")
-      .text(d.data.label);
+    .data(pie(data))
+    .enter()
+    .append("text")
+    .attr("transform", d => `translate(${arc.centroid(d)})`)
+    .style("text-anchor", "middle")
+    .style("font-size", "14px")
+    .style("fill", "#333")
+    .each(function (d) {
+      const text = d3.select(this);
+      text.append("tspan")
+        .attr("x", 0)
+        .attr("dy", "0em")
+        .text(d.data.label);
 
-    // Line 2: Count
-    text.append("tspan")
-      .attr("x", 0)
-      .attr("dy", "1.2em")
-      .style("font-size", "12px")
-      .style("fill", "#555")
-      .text(`(${d.data.count})`);
-  });
+      text.append("tspan")
+        .attr("x", 0)
+        .attr("dy", "1.2em")
+        .style("font-size", "12px")
+        .style("fill", "#555")
+        .text(`(${d.data.count})`);
+    });
 }

--- a/uli-community/lib/uli_community/user_contribution.ex
+++ b/uli-community/lib/uli_community/user_contribution.ex
@@ -156,4 +156,12 @@ defmodule UliCommunity.UserContribution do
     |> limit(^n)
     |> Repo.all()
   end
+
+  def get_severity_distribution do
+  UliCommunity.UserContribution.CrowdsourcedSlur
+  |> group_by([s], s.level_of_severity)
+  |> select([s], %{label: s.level_of_severity, count: count(s.id)})
+  |> Repo.all()
+end
+
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.ex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.ex
@@ -6,12 +6,17 @@ defmodule UliCommunityWeb.DashboardLive do
 
   def mount(_params, _session, socket) do
     if connected?(socket), do: Phoenix.PubSub.subscribe(UliCommunity.PubSub, @topic)
+
     slurs = UserContribution.get_top_slurs(10)
-    {:ok, assign(socket, slurs: slurs)}
+    severity_data = UserContribution.get_severity_distribution()
+
+    {:ok, assign(socket, slurs: slurs, severity_data: severity_data)}
   end
 
   def handle_info(:slur_changed, socket) do
     slurs = UserContribution.get_top_slurs(10)
-    {:noreply, assign(socket, slurs: slurs)}
+    severity_data = UserContribution.get_severity_distribution()
+
+    {:noreply, assign(socket, slurs: slurs, severity_data: severity_data)}
   end
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
@@ -1,8 +1,17 @@
 <div class="p-4">
-     <h2 class="text-xl font-bold mb-4">Dashboard</h2>
-     <div id="bar-chart"
-          phx-hook="BarChartHook"
-          data-bar={Jason.encode!(@slurs)}
-          class="w-full h-96 mt-10">
-     </div>
+  <h2 class="text-xl font-bold mb-4">Dashboard</h2>
+
+  <div class="text-center">
+    <div class="inline-block align-top w-full lg:w-[48%] h-96 mr-2"
+         id="bar-chart"
+         phx-hook="BarChartHook"
+         data-bar={Jason.encode!(@slurs)}>
+    </div>
+
+    <div class="inline-block align-top w-full lg:w-[48%] h-96"
+         id="pie-chart"
+         phx-hook="PieChartHook"
+         data-severity={Jason.encode!(@severity_data)}>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
### PR Description
This pull request implements a pie chart visualization on the Dashboard page to show the distribution of crowdsourced slurs based on their `level_of_severity` field (low, medium, high). The chart is built using D3.js and is displayed alongside the existing bar chart.

**Features Added :-**

- Created a new D3-based pie chart component to represent severity-level distribution.
- Integrated the pie chart into the existing dashboard layout beside the bar chart.

**Ecto Functions Used :-**
To prepare the severity data for the pie chart, the following Ecto functions were used:
```
def get_severity_distribution do
  UliCommunity.UserContribution.CrowdsourcedSlur
  |> group_by([s], s.level_of_severity)
  |> select([s], %{label: s.level_of_severity, count: count(s.id)})
  |> Repo.all()
end
```
**Explanation :-**

- `group_by/2` groups the slurs by their `level_of_severity` field.
- `select/2` returns a map with the label (severity level) and count (number of slurs in that group).
- `Repo.all/1` executes the query and returns a list of maps, each representing a severity level and its count.
- This data is passed to the frontend and rendered using `D3.js` to produce a clean, informative pie chart.

**Screenshot :-**
![Screenshot from 2025-06-16 15-48-23](https://github.com/user-attachments/assets/65dca3da-7649-4096-837d-ad78f766885c)

**Related Issue :-**
This PR addresses [Issue #789](https://github.com/tattle-made/Uli/issues/789).
