### PR TITLE
Add D3 bar chart to dashboard for slur source distribution

### DIFF
--- a/uli-community/assets/js/app.js
+++ b/uli-community/assets/js/app.js
@@ -24,6 +24,7 @@ import topbar from "../vendor/topbar";
 import { drawPieChart } from "./pie_chart.js";
 import { PieChartHook } from "./hooks/pie_chart_hook";
 import { BarChartHook } from "./hooks/bar_chart_hook.js";
+import { SourceBarChartHook } from "./hooks/source_bar_chart_hook.js";
 
 
 
@@ -34,6 +35,7 @@ let csrfToken = document
 let Hooks = {};
 Hooks.PieChartHook = PieChartHook;
 Hooks.BarChartHook = BarChartHook
+Hooks.SourceBarChartHook = SourceBarChartHook
 
 let liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,

--- a/uli-community/assets/js/hooks/source_bar_chart_hook.js
+++ b/uli-community/assets/js/hooks/source_bar_chart_hook.js
@@ -1,0 +1,10 @@
+import { drawSourceBarChart } from "../source_bar_chart";
+
+export const SourceBarChartHook = {
+  mounted() {
+    drawSourceBarChart();
+  },
+  updated() {
+    drawSourceBarChart();
+  }
+};

--- a/uli-community/assets/js/source_bar_chart.js
+++ b/uli-community/assets/js/source_bar_chart.js
@@ -1,0 +1,65 @@
+import * as d3 from "d3";
+
+export function drawSourceBarChart() {
+  const container = document.querySelector("#source-bar-chart");
+  if (!container || !container.dataset.source) return;
+
+  const data = JSON.parse(container.dataset.source);
+  if (!Array.isArray(data) || data.length === 0) return;
+
+  d3.select(container).select("svg").remove();
+
+  const margin = { top: 20, right: 30, bottom: 40, left: 60 };
+  const width = 600 - margin.left - margin.right;
+  const height = 300 - margin.top - margin.bottom;
+
+  const svg = d3.select(container)
+    .append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+    .attr("transform", `translate(${margin.left},${margin.top})`);
+
+  const x = d3.scaleBand()
+    .domain(data.map(d => d.source))
+    .range([0, width])
+    .padding(0.2);
+
+  const y = d3.scaleLinear()
+    .domain([0, d3.max(data, d => d.count)])
+    .nice()
+    .range([height, 0]);
+
+  svg.append("g")
+    .attr("transform", `translate(0, ${height})`)
+    .call(d3.axisBottom(x))
+    .selectAll("text")
+    .style("font-size", "12px");
+
+  svg.append("g")
+    .call(d3.axisLeft(y))
+    .selectAll("text")
+    .style("font-size", "12px");
+
+  svg.selectAll(".bar")
+    .data(data)
+    .enter()
+    .append("rect")
+    .attr("class", "bar")
+    .attr("x", d => x(d.source))
+    .attr("y", d => y(d.count))
+    .attr("width", x.bandwidth())
+    .attr("height", d => height - y(d.count))
+    .attr("fill", "#70234B");
+
+  svg.selectAll(".label")
+    .data(data)
+    .enter()
+    .append("text")
+    .attr("x", d => x(d.source) + x.bandwidth() / 2)
+    .attr("y", d => y(d.count) - 5)
+    .attr("text-anchor", "middle")
+    .style("font-size", "12px")
+    .style("fill", "#333")
+    .text(d => d.count);
+}

--- a/uli-community/lib/uli_community/user_contribution.ex
+++ b/uli-community/lib/uli_community/user_contribution.ex
@@ -160,4 +160,11 @@ defmodule UliCommunity.UserContribution do
     |> select([s], %{label: s.level_of_severity, count: count(s.id)})
     |> Repo.all()
   end
+
+  def get_source_distribution do
+    CrowdsourcedSlur
+    |> group_by([s], s.source)
+    |> select([s], %{source: s.source, count: count(s.id)})
+    |> Repo.all()
+  end
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.ex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.ex
@@ -18,6 +18,18 @@ defmodule UliCommunityWeb.DashboardLive do
         _ -> nil
       end
 
-    {:ok, assign(socket, slurs: slurs, severity_data: severity_data)}
+    source_data =
+      try do
+        UserContribution.get_source_distribution()
+      rescue
+        _ -> nil
+      end
+
+    {:ok,
+     assign(socket,
+       slurs: slurs,
+       severity_data: severity_data,
+       source_data: source_data
+     )}
   end
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
@@ -1,38 +1,55 @@
 <div class="p-4">
   <h2 class="text-xl font-bold mb-4">Dashboard</h2>
 
-  <div class="flex flex-col lg:flex-row text-center">
+  <!-- First Row: Slurs Chart + Severity Chart -->
+  <div class="flex flex-col lg:flex-row text-center gap-4">
+    
     <!-- Slurs Chart -->
-    <div class="flex-1">
+    <div class="flex-1 p-4">
       <h3 class="text-lg font-semibold mb-2">Top 10 Contributed Slurs</h3>
-
       <%= if @slurs do %>
         <div
-          class="inline-block align-top w-full h-96"
           id="bar-chart"
           phx-hook="BarChartHook"
           data-bar={Jason.encode!(@slurs)}
+          class="inline-block align-top w-full h-96"
         >
         </div>
       <% else %>
         <p class="text-red-600">Unable to load slur data</p>
       <% end %>
     </div>
-    <!-- Severity Chart -->
-    <div class="flex-1">
-      <h3 class="text-lg font-semibold mb-2">Severity Distribution</h3>
 
+    <!-- Severity Chart -->
+    <div class="flex-1 p-4">
+      <h3 class="text-lg font-semibold mb-2">Severity Distribution</h3>
       <%= if @severity_data do %>
         <div
-          class="inline-block align-top h-96"
           id="pie-chart"
           phx-hook="PieChartHook"
           data-severity={Jason.encode!(@severity_data)}
+          class="inline-block align-top w-full h-96"
         >
         </div>
       <% else %>
         <p class="text-red-600">Unable to load severity data</p>
       <% end %>
     </div>
+  </div>
+
+  <!-- Second Row: Source Contribution Chart -->
+  <div class="mt-8 p-4">
+    <h3 class="text-lg font-semibold mb-2">Slur Contributions by Source</h3>
+    <%= if @source_data do %>
+      <div
+        id="source-bar-chart"
+        phx-hook="SourceBarChartHook"
+        data-source={Jason.encode!(@source_data)}
+        class="inline-block align-top w-full h-96"
+      >
+      </div>
+    <% else %>
+      <p class="text-red-600 text-center">Unable to load source data</p>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Pull Request Description:
This pull request implements the feature described in [Issue #790](https://github.com/tattle-made/Uli/issues/790), which requires displaying a bar chart on the `/dashboard` page showing the number of slurs contributed from each source (such as expert, plugin, crowdsourcing_session). The chart is built using D3.js.

**Features Implemented:**

**1. API Added**

- Function:` get_source_distribution/0`
- Module: `UliCommunity.UserContribution`
- Description: Groups slurs by the `source` field and returns the count for each group.
```
def get_source_distribution do
  CrowdsourcedSlur
  |> group_by([s], s.source)
  |> select([s], %{label: s.source, count: count(s.id)})
  |> Repo.all()
end
```
**2. LiveView Update**

- File: `dashboard_live.ex`
- Description: Fetched source distribution data by calling the `get_source_distribution` function and assigned it to `@source_data` during the LiveView mount phase.

**3. Template Update**

- File: `dashboard_live.html.heex`
- Description:

-    Added a new chart section for "Slur Contributions by Source"
-    Attached the D3.js hook `SourceBarChartHook` to a `div` element with `id="source-bar-chart"`
-    Passed the source data using `data-source={Jason.encode!(@source_data)}`

**4. JavaScript Chart Implementation**

- File: `source_bar_chart.js`
- Hook Function: `drawSourceBarChart()`
- Description: Reads the data from the DOM, parses it, and renders a bar chart using D3.js. The chart uses scaleBand for the x- 
axis and scaleLinear for the y-axis.

**How to Test:**

- Seed the database with sample data using the file:
`  scripts/seed_crowdsourced_slur_data_21_05_25.ex`
- Run the Phoenix server and visit:
`  http://localhost:4000/dashboard`
- Confirm that a new bar chart appears below the existing charts showing the number of slurs grouped by their source.

**Screenshot :-**
![Screenshot from 2025-06-18 12-55-59](https://github.com/user-attachments/assets/60c3a27d-cae8-4666-8c6f-a4f2bb5abc7e)
