### PR TITLE
Add weekly slur submission data aggregation and line chart to dashboard

### DIFF
--- a/uli-community/assets/js/app.js
+++ b/uli-community/assets/js/app.js
@@ -25,6 +25,7 @@ import { drawPieChart } from "./pie_chart.js";
 import { PieChartHook } from "./hooks/pie_chart_hook";
 import { BarChartHook } from "./hooks/bar_chart_hook.js";
 import { SourceBarChartHook } from "./hooks/source_bar_chart_hook.js";
+import { WeeklyLineChartHook } from "./hooks/weekly_line_chart_hook.js";
 
 
 
@@ -36,6 +37,7 @@ let Hooks = {};
 Hooks.PieChartHook = PieChartHook;
 Hooks.BarChartHook = BarChartHook
 Hooks.SourceBarChartHook = SourceBarChartHook
+Hooks.WeeklyLineChartHook = WeeklyLineChartHook
 
 let liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,

--- a/uli-community/assets/js/hooks/weekly_line_chart_hook.js
+++ b/uli-community/assets/js/hooks/weekly_line_chart_hook.js
@@ -1,0 +1,10 @@
+import { drawWeeklyLineChart } from "../weekly_slur_line_chart"
+
+export const WeeklyLineChartHook = {
+  mounted() {
+    drawWeeklyLineChart()
+  },
+  updated() {
+    drawWeeklyLineChart()
+  }
+}

--- a/uli-community/assets/js/pie_chart.js
+++ b/uli-community/assets/js/pie_chart.js
@@ -13,8 +13,8 @@ export function drawPieChart() {
 
   d3.select("#pie-chart").select("svg").remove();
 
-  const width = 500;
-  const height = 500;
+  const width = 450;
+  const height = 450;
   const radius = width / 2;
 
   const svg = d3.select("#pie-chart")

--- a/uli-community/assets/js/weekly_slur_line_chart.js
+++ b/uli-community/assets/js/weekly_slur_line_chart.js
@@ -1,0 +1,74 @@
+import * as d3 from "d3";
+
+export function drawWeeklyLineChart() {
+  const container = document.querySelector("#weekly-line-chart");
+  const data = JSON.parse(container.dataset.weekly);
+
+  if (!data || data.length === 0) return;
+  d3.select("#weekly-line-chart").select("svg").remove();
+
+  const margin = { top: 30, right: 30, bottom: 80, left: 50 };
+  const width = 700 - margin.left - margin.right;
+  const height = 400 - margin.top - margin.bottom;
+
+  const svg = d3.select("#weekly-line-chart")
+    .append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+    .append("g")
+    .attr("transform", `translate(${margin.left},${margin.top})`);
+
+  // Format dates from ISO strings to readable format like '4 Jun 2025'
+  const parseDate = d3.timeParse("%Y-%m-%d");
+  const formatDate = d3.timeFormat("%-d %b %Y");
+
+  data.forEach(d => {
+    d.date = parseDate(d.week_start_date); // must be YYYY-MM-DD
+    d.label = formatDate(d.date);
+  });
+
+  const xScale = d3.scalePoint()
+    .domain(data.map(d => d.label))
+    .range([0, width]);
+
+  const yScale = d3.scaleLinear()
+    .domain([0, d3.max(data, d => d.count)])
+    .nice()
+    .range([height, 0]);
+
+  const line = d3.line()
+    .x(d => xScale(d.label))
+    .y(d => yScale(d.count))
+    .curve(d3.curveMonotoneX);
+
+  svg.append("path")
+    .datum(data)
+    .attr("fill", "none")
+    .attr("stroke", "#4D5182")
+    .attr("stroke-width", 3)
+    .attr("d", line);
+
+  // X Axis
+  svg.append("g")
+    .attr("transform", `translate(0, ${height})`)
+    .call(d3.axisBottom(xScale))
+    .selectAll("text")
+    .style("text-anchor", "end")
+    .attr("dx", "-0.8em")
+    .attr("dy", "0.15em")
+    .attr("transform", "rotate(-40)");
+
+  // Y Axis
+  svg.append("g")
+    .call(d3.axisLeft(yScale).ticks(6));
+
+  // Points
+  svg.selectAll("circle")
+    .data(data)
+    .enter()
+    .append("circle")
+    .attr("cx", d => xScale(d.label))
+    .attr("cy", d => yScale(d.count))
+    .attr("r", 4)
+    .attr("fill", "#020637");
+}

--- a/uli-community/lib/uli_community/user_contribution.ex
+++ b/uli-community/lib/uli_community/user_contribution.ex
@@ -167,4 +167,33 @@ defmodule UliCommunity.UserContribution do
     |> select([s], %{source: s.source, count: count(s.id)})
     |> Repo.all()
   end
+
+ def get_weekly_submission_counts do
+  weekly_data =
+    Repo.all(
+      from(cs in CrowdsourcedSlur,
+        where: not is_nil(cs.inserted_at),
+        group_by: fragment("date_trunc('week', ?)", cs.inserted_at),
+        order_by: fragment("date_trunc('week', ?)", cs.inserted_at),
+        select: %{
+          week_start: fragment("date_trunc('week', ?)", cs.inserted_at),
+          count: count(cs.id)
+        }
+      )
+    )
+
+  Enum.map(weekly_data, fn %{week_start: week_start, count: count} ->
+    %{
+      week_start_date: to_iso_date(week_start),
+      count: count
+    }
+  end)
+end
+
+defp to_iso_date(naive_date) do
+  naive_date
+  |> NaiveDateTime.to_date()
+  |> Date.to_iso8601()
+end
+
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.ex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.ex
@@ -25,11 +25,19 @@ defmodule UliCommunityWeb.DashboardLive do
         _ -> nil
       end
 
+    weekly_submissions_data =
+      try do
+        UserContribution.get_weekly_submission_counts()
+      rescue
+        _ -> nil
+      end
+
     {:ok,
      assign(socket,
        slurs: slurs,
        severity_data: severity_data,
-       source_data: source_data
+       source_data: source_data,
+       weekly_submissions_data: weekly_submissions_data
      )}
   end
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
@@ -13,8 +13,7 @@
           phx-hook="BarChartHook"
           data-bar={Jason.encode!(@slurs)}
           class="inline-block align-top w-full h-96"
-        >
-        </div>
+        ></div>
       <% else %>
         <p class="text-red-600">Unable to load slur data</p>
       <% end %>
@@ -29,27 +28,44 @@
           phx-hook="PieChartHook"
           data-severity={Jason.encode!(@severity_data)}
           class="inline-block align-top w-full h-96"
-        >
-        </div>
+        ></div>
       <% else %>
         <p class="text-red-600">Unable to load severity data</p>
       <% end %>
     </div>
   </div>
 
-  <!-- Second Row: Source Contribution Chart -->
-  <div class="mt-8 p-4">
-    <h3 class="text-lg font-semibold mb-2">Slur Contributions by Source</h3>
-    <%= if @source_data do %>
-      <div
-        id="source-bar-chart"
-        phx-hook="SourceBarChartHook"
-        data-source={Jason.encode!(@source_data)}
-        class="inline-block align-top w-full h-96"
-      >
-      </div>
-    <% else %>
-      <p class="text-red-600 text-center">Unable to load source data</p>
-    <% end %>
+  <!-- Second Row: Source Chart + Weekly Submissions -->
+  <div class="flex flex-col lg:flex-row text-center gap-4 mt-8">
+    
+    <!-- Source Contribution Chart -->
+    <div class="flex-1 p-4">
+      <h3 class="text-lg font-semibold mb-2">Slur Contributions by Source</h3>
+      <%= if @source_data do %>
+        <div
+          id="source-bar-chart"
+          phx-hook="SourceBarChartHook"
+          data-source={Jason.encode!(@source_data)}
+          class="inline-block align-top w-full h-96 mt-20"
+        ></div>
+      <% else %>
+        <p class="text-red-600 text-center">Unable to load source data</p>
+      <% end %>
+    </div>
+
+    <!-- Weekly Slur Submissions Line Chart -->
+    <div class="flex-1 p-4 mt-5">
+      <h3 class="text-lg font-semibold mb-2">Weekly Slur Submissions</h3>
+      <%= if @weekly_submissions_data do %>
+        <div
+          id="weekly-line-chart"
+          phx-hook="WeeklyLineChartHook"
+          data-weekly={Jason.encode!(@weekly_submissions_data)}
+          class="inline-block align-top w-full h-96"
+        ></div>
+      <% else %>
+        <p class="text-red-600 text-center">Unable to load weekly submission data</p>
+      <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
### Pull Request Description
This PR solves [Issue #791](https://github.com/tattle-made/Uli/issues/791).
The goal of this issue was to show how many slurs were submitted every week, using a **line chart** on the `/dashboard` page. This chart helps us understand changes in submission activity over time.

### What I did
**1. Wrote a backend function to get weekly data**
I created a function called `get_weekly_submission_counts/0` that fetches the number of slurs submitted each week.
Here’s what it does:

- It uses inserted_at from the crowdsourced_slurs table.
- Groups the data by week using PostgreSQL's date_trunc('week', inserted_at) function.
- Counts how many slurs were submitted in each week.
- Converts the date to a simple ISO format like "2025-06-04".

```
def get_weekly_submission_counts do
  weekly_data =
    Repo.all(
      from(cs in CrowdsourcedSlur,
        where: not is_nil(cs.inserted_at),
        group_by: fragment("date_trunc('week', ?)", cs.inserted_at),
        order_by: fragment("date_trunc('week', ?)", cs.inserted_at),
        select: %{
          week_start: fragment("date_trunc('week', ?)", cs.inserted_at),
          count: count(cs.id)
        }
      )
    )

  Enum.map(weekly_data, fn %{week_start: week_start, count: count} ->
    %{
      week_start_date: to_iso_date(week_start),
      count: count
    }
  end)
end
```
Helper function:
```
defp to_iso_date(naive_date) do
  naive_date
  |> NaiveDateTime.to_date()
  |> Date.to_iso8601()
end
```
**2. Added a line chart using D3.js**

- I created a new chart using D3.js to display this weekly data.
- The chart is shown on the dashboard page, with the ID `weekly-line-chart`.
- X-axis shows weekly ranges (like` 4 Jun 2025`, `28 May 2025`, etc.).
- Y-axis shows how many slurs were submitted that week.
- This helps users clearly see the trend over time.

**3. Updated dashboard layout**

- The dashboard now has 2 charts in the **second row**:
    -      One is for **Source Contributions**
    -      The other is the new **Weekly Line Chart**
I used Tailwind classes like` flex-1`, `p-4,` `h-96`, and `gap-4 `to make the layout responsive and clean.

### How to test this
To test locally, run the seed file:
`mix run scripts/seed_crowdsourced_slur_data_21_05_25.ex`
This will add sample slur data for different weeks, so that you can see the line chart with proper values.

### Sreenshot :-
![Screenshot from 2025-06-18 20-49-15](https://github.com/user-attachments/assets/b3a52d90-586b-4634-be24-beab26939ca4)

