### PR TITLE
Applied Uli theme colors across all charts (bar, pie, line) for consi…

### DIFF
--- a/uli-community/assets/js/bar_chart.js
+++ b/uli-community/assets/js/bar_chart.js
@@ -41,7 +41,7 @@ export function drawBarChart() {
     .attr("x", 0)
     .attr("height", y.bandwidth())
     .attr("width", d => x(d.count))
-    .attr("fill", "#252653");
+    .attr("fill", "#212121");
 
   svg.selectAll("text.bar-label")
     .data(data)

--- a/uli-community/assets/js/pie_chart.js
+++ b/uli-community/assets/js/pie_chart.js
@@ -27,7 +27,7 @@ export function drawPieChart() {
   // Color mapping based on severity level
   const color = d3.scaleOrdinal()
     .domain(["low", "medium", "high"])
-    .range(["#FCBFA4", "#F4C6D7", "#F39695"]); 
+    .range(["#f2a24a", "#e58224", "#de8821"]); 
 
   const pie = d3.pie().value(d => d.count);
   const arc = d3.arc().innerRadius(0).outerRadius(radius);

--- a/uli-community/assets/js/source_bar_chart.js
+++ b/uli-community/assets/js/source_bar_chart.js
@@ -50,7 +50,7 @@ export function drawSourceBarChart() {
     .attr("y", d => y(d.count))
     .attr("width", x.bandwidth())
     .attr("height", d => height - y(d.count))
-    .attr("fill", "#70234B");
+    .attr("fill", "#de8821");
 
   svg.selectAll(".label")
     .data(data)

--- a/uli-community/assets/js/weekly_slur_line_chart.js
+++ b/uli-community/assets/js/weekly_slur_line_chart.js
@@ -44,7 +44,7 @@ export function drawWeeklyLineChart() {
   svg.append("path")
     .datum(data)
     .attr("fill", "none")
-    .attr("stroke", "#4D5182")
+    .attr("stroke", "#e58224")
     .attr("stroke-width", 3)
     .attr("d", line);
 
@@ -70,5 +70,5 @@ export function drawWeeklyLineChart() {
     .attr("cx", d => xScale(d.label))
     .attr("cy", d => yScale(d.count))
     .attr("r", 4)
-    .attr("fill", "#020637");
+    .attr("fill", "#212121");
 }


### PR DESCRIPTION
## Description

This pull request updates the colors of all chart components to match the Uli theme. The goal is to make all charts look consistent with the overall design of the website.

## Changes Made

1. **weekly_slur_line_chart.js**
   - Used `#212121` for the line and dots
   - Also used `#e58224` for highlighting

2. **bar_chart.js**
   - Used `#212121` as the main bar color

3. **pie_chart.js**
   - Used different colors based on value levels:
     - Low: `#f2a24a`
     - Medium: `#e58224`
     - High: `#de8821`

4. **source_bar_chart.js**
   - Used `#de8821` as the main bar color

## Purpose

- To apply Uli’s brand colors to all charts
- To make the UI look clean and consistent
- To improve how charts look on the light background

## Notes

- Only colors were updated
- No changes were made to data or logic

### Screenshot
![Uploading Screenshot from 2025-06-19 15-05-07.png…]()

