### PR TITLE
Add unique slur count display to Dashboard page

### DIFF
--- a/uli-community/lib/uli_community_web/live/dashboard_live.ex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.ex
@@ -32,12 +32,20 @@ defmodule UliCommunityWeb.DashboardLive do
         _ -> nil
       end
 
+    unique_slur_count =
+      try do
+        UserContribution.get_unique_slur_count()
+      rescue
+        _ -> nil
+      end
+
     {:ok,
      assign(socket,
        slurs: slurs,
        severity_data: severity_data,
        source_data: source_data,
-       weekly_submissions_data: weekly_submissions_data
+       weekly_submissions_data: weekly_submissions_data,
+       unique_slur_count: unique_slur_count
      )}
   end
 end

--- a/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/dashboard_live.html.heex
@@ -1,5 +1,8 @@
 <div class="p-4">
   <h2 class="text-xl font-bold mb-4">Dashboard</h2>
+  <p class="text-lg font-semibold mb-4">
+    Total Unique Slurs: <%= @unique_slur_count || "Loading..." %>
+  </p>
 
   <!-- First Row: Slurs Chart + Severity Chart -->
   <div class="flex flex-col lg:flex-row text-center gap-4">


### PR DESCRIPTION
### PR Title: Show Total Unique Slurs on Dashboard
**Related Issue:** [#792](https://github.com/tattle-made/Uli/issues/792)
### Description
This PR adds a simple display element on the `/dashboard` page that shows the **total number of unique slurs** present in the `crowdsourced_slurs `table.

### What has been done
**1. A new function `get_unique_slur_count/0` is added:**
```
def get_unique_slur_count do
  Repo.one(
    from(cs in CrowdsourcedSlur,
      select: count(fragment("DISTINCT lower(?)", cs.label))
    )
  )
end
```
### Explanation:
This query counts how many different (distinct) slur labels exist in the table.
It uses `lower(?)` to make sure the count is case-insensitive, so `Abuse` and `abuse` are treated as the same slur.

**2. This count is fetched in the LiveView and assigned to the socket:**
```
unique_slur_count =
  try do
    UserContribution.get_unique_slur_count()
  rescue
    _ -> nil
  end

assign(socket,
  slurs: slurs,
  severity_data: severity_data,
  source_data: source_data,
  weekly_submissions_data: weekly_submissions_data,
  unique_slur_count: unique_slur_count
)
```
### Explanation:
The function is wrapped in `try-rescue` to prevent crashing if an error occurs.
The value is assigned to the socket so it can be shown in the HTML.

**3. Display added in the dashboard UI:**
```
<p class="text-lg font-semibold mb-4">
  Total Unique Slurs: <%= @unique_slur_count || "Loading..." %>
</p>
```
### Explanation:
This line displays the total unique slurs.
If the value is not yet loaded, it shows "Loading..." as a fallback.

### Summary

- Case-insensitive unique slur count is added
- Count is shown on `/dashboard`
- Data is handled safely using `try-rescue`
- Seed file can be used to test with sample data

### Screenshot :- 
![Screenshot from 2025-06-23 12-54-55](https://github.com/user-attachments/assets/d5e6534b-a1ea-4428-9bca-c7b3e90a2e4c)
