### PR TITLE
Fix(#825): prevent link overflow on research page to avoid layout shift

### DIFF
--- a/uli-website/src/pages/research.mdx
+++ b/uli-website/src/pages/research.mdx
@@ -12,7 +12,10 @@ The Uli team is cross-disciplinary. This is the list of publications based on wo
 - Mehta, T., & Chakraborty, S. (2023). Visuais Para Tecnologia Emancipatória: Um Estudo de Caso Sobre a Cocriação de uma Linguagem Visual Para Combater a Violência de Género Online no Twitter Indiano. Vista, (11), e023007. [https://doi.org/10.21814/vista.4133](https://doi.org/10.21814/vista.4133)
 - Arora, A., Arora, C., & J, M. (2023). Designing for Disagreements: A Machine Learning Tool to Detect Online Gender-based Violence. In Feminist Perspectives on Social Media Governance. IT for Change. [https://itforchange.net/feminist-perspectives-on-social-media-governance-0](https://itforchange.net/feminist-perspectives-on-social-media-governance-0)
 - Arora, C., & Prabhakar, T. To think interdisciplinarity as intercurrence: Or, working as an interdisciplinary team to develop a plug-in to tackle the experience of online gender-based violence and hate speech. 2021. [⟨hal-03505844⟩](https://hal.science/hal-03505844)
-- Arora, C. (2022). ...The tool is underdevelopment... In R. Singh, R. L. Guzmán, & P. Davison (Eds.), Parables of AI in/from the Majority World. [https://datasociety.net/wp-content/uploads/2022/12/DSParablesAnthology_Ch5_Arora.pdf](https://datasociety.net/wp-content/uploads/2022/12/DSParablesAnthology_Ch5_Arora.pdf)
+- Arora, C. (2022). ...The tool is underdevelopment...  
+  In R. Singh, R. L. Guzmán, & P. Davison (Eds.), Parables of AI in/from the Majority World.
+  [Read the full chapter here](https://datasociety.net/wp-content/uploads/2022/12/DSParablesAnthology_Ch5_Arora.pdf)
+ 
 
 ## Responsible/ Trustworthy/ Feminist AI
 


### PR DESCRIPTION
Fixes #825

### Summary
Fixed an issue on the Research page where long links were overflowing and causing layout shift on small screens.

### Changes Made
- Replaced the raw URL with a markdown link:  
  `[Read the full chapter here](https://datasociety.net/wp-content/uploads/2022/12/DSParablesAnthology_Ch5_Arora.pdf)`  
- This makes the link more user-friendly and prevents overflow.  

### Screenshot
<img width="432" height="166" alt="image" src="https://github.com/user-attachments/assets/6029ea84-8836-401e-9395-354f2901178f" />
