### PR TITLE
Make Crowdsource Contributions page responsive for all screens

### DIFF
--- a/uli-community/lib/uli_community_web/components/core_components.ex
+++ b/uli-community/lib/uli_community_web/components/core_components.ex
@@ -478,57 +478,81 @@ defmodule UliCommunityWeb.CoreComponents do
   slot :action, doc: "the slot for showing user actions in the last table column"
 
   def table(assigns) do
-    assigns =
-      with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
-        assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
-      end
+  assigns =
+    with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
+      assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
+    end
 
-    ~H"""
-    <div class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
-      <table class="w-[40rem] mt-11 sm:w-full">
-        <thead class="text-sm text-center leading-6 text-zinc-500">
-          <tr>
-            <th :for={col <- @col} class="p-0 pb-4 pr-6 font-normal"><%= col[:label] %></th>
-            <th :if={@action != []} class="relative p-0 pb-4">
-              <span class="sr-only"><%= gettext("Actions") %></span>
-            </th>
-          </tr>
-        </thead>
-        <tbody
-          id={@id}
-          phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
-          class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700"
+  ~H"""
+  <div class="overflow-x-auto overflow-y-auto max-h-[500px] px-4 sm:overflow-visible sm:px-0">
+    <table class="w-[40rem] mt-11 sm:w-full border-collapse">
+      <thead class="text-sm text-center leading-6 text-zinc-500">
+        <tr>
+          <th
+            :for={{col, i} <- Enum.with_index(@col)}
+            class={[
+              "p-0 pb-4 pr-6 font-normal",
+              "max-sm:sticky max-sm:top-0 max-sm:bg-white max-sm:z-20",
+              i == 0 && "max-sm:left-0 max-sm:z-30"
+            ]}
+          >
+            <%= col[:label] %>
+          </th>
+          <th
+            :if={@action != []}
+            class="relative p-0 pb-4 max-sm:sticky max-sm:top-0 max-sm:z-20 max-sm:bg-white"
+          >
+            <span class="sr-only"><%= gettext("Actions") %></span>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody
+        id={@id}
+        phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
+        class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700"
+      >
+        <tr
+          :for={row <- @rows}
+          id={@row_id && @row_id.(row)}
+          class="group hover:bg-slate-200"
         >
-          <tr :for={row <- @rows} id={@row_id && @row_id.(row)} class="group hover:bg-slate-200">
-            <td
-              :for={{col, i} <- Enum.with_index(@col)}
-              phx-click={@row_click && @row_click.(row)}
-              class={["relative p-0 text-center", @row_click && "hover:cursor-pointer"]}
-            >
-              <div class="block py-4 pr-6">
-                <span class="absolute -inset-y-px right-0 -left-4 group-hover:bg-slate-200 sm:rounded-l-xl" />
-                <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
-                  <%= render_slot(col, @row_item.(row)) %>
-                </span>
-              </div>
-            </td>
-            <td :if={@action != []} class="relative w-14 p-0">
-              <div class="relative whitespace-nowrap py-4 text-right text-sm font-medium">
-                <span class="absolute -inset-y-px -right-4 left-0 group-hover:bg-slate-200 sm:rounded-r-xl" />
-                <span
-                  :for={action <- @action}
-                  class="relative ml-4 font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
-                >
-                  <%= render_slot(action, @row_item.(row)) %>
-                </span>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    """
-  end
+          <td
+            :for={{col, i} <- Enum.with_index(@col)}
+            phx-click={@row_click && @row_click.(row)}
+            class={[
+              "relative p-0 text-center",
+              @row_click && "hover:cursor-pointer",
+              # first column सिर्फ phone पर sticky
+              i == 0 && "max-sm:sticky max-sm:left-0 max-sm:z-20 max-sm:bg-white"
+            ]}
+          >
+            <div class="block py-4 pr-6">
+              <span class=" right-0 -left-4 group-hover:bg-slate-200 sm:rounded-l-xl" />
+              <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
+                <%= render_slot(col, @row_item.(row)) %>
+              </span>
+            </div>
+          </td>
+
+          <td :if={@action != []} class="relative w-14 p-0">
+            <div class="relative whitespace-nowrap py-4 text-right text-sm font-medium">
+              <span class="-right-4 left-0 group-hover:bg-slate-200 sm:rounded-r-xl" />
+              <span
+                :for={action <- @action}
+                class="relative ml-4 font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
+              >
+                <%= render_slot(action, @row_item.(row)) %>
+              </span>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  """
+end
+
 
   @doc """
   Renders a data list.

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
@@ -836,7 +836,7 @@
       <% end %>
     </div>
 
-    <!-- Apply / Clear -->
+    <!-- Clear -->
     <div class="flex justify-between mt-6">
       <!-- Clear Filters behaves like desktop Clear All -->
       <.link
@@ -847,17 +847,6 @@
       >
         Clear Filters
       </.link>
-
-      <button
-        phx-click={
-        JS.hide(to: "#mobile-filters")
-        |> JS.remove_class("hidden", to: "#mobile-filter-button")
-        }
-        class="px-4 py-2 rounded-lg"
-        style="background-color: rgb(231, 109, 103); color: rgb(81, 78, 128);"
-        >
-        Apply
-      </button>
     </div>
   </div>
 </div>

--- a/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
+++ b/uli-community/lib/uli_community_web/live/crowdsource_contributions_live.html.heex
@@ -129,20 +129,26 @@
   Crowdsource Contributions
 </.header>
 
-<div class="flex justify-between items-center mb-4">
-  <div class="text-xl font-normal text-slate-900">
-    <h1><%= "Showing all #{@query_count} contributions" %></h1>
+<div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-4 gap-4">
+  <!-- Left Side -->
+  <div class="text-slate-900">
+    <!-- Responsive heading -->
+    <h1 class="text-base sm:text-lg md:text-xl font-normal truncate">
+      <%= "Showing all #{@query_count} contributions" %>
+    </h1>
 
+    <!-- Clear Filters (only tablet/laptop and larger) -->
     <.link
       href={
         ~p"/crowdsource-contributions?page_num=1&sort=newest&level_of_severity=all&casual=all&appropriated=all&source=all"
       }
-      class="mt-4 inline-flex items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700 transition-colors"
+      class="hidden md:inline-flex mt-4 items-center gap-1 text-sm text-zinc-500 hover:text-zinc-700 transition-colors"
     >
       <.icon name="hero-x-circle" class="w-4 h-4" />
       <span>Clear All Filters</span>
     </.link>
 
+    <!-- Advanced Search -->
     <form phx-change="toggle-advanced-search" class="flex items-center mt-4 text-sm text-zinc-600">
       <input
         type="checkbox"
@@ -157,14 +163,15 @@
     </form>
   </div>
 
-  <div class="flex items-center gap-2">
-    <form phx-submit="search" class="relative flex">
+  <!-- Right Side (Search bar) -->
+  <div class="w-full md:w-auto flex items-center gap-2">
+    <form phx-submit="search" class="relative w-full md:w-64 flex">
       <input
         type="text"
         name="search"
         placeholder="Search slurs..."
         value={Keyword.get(@search_params, :search, "")}
-        class="w-64 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+        class="w-full md:w-64 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-gray-500 focus:border-transparent"
       />
       <button
         type="submit"
@@ -176,8 +183,9 @@
   </div>
 </div>
 
+
 <div class="flex flex-col sm:flex-row">
-  <div class="h-fit w-full sm:w-1/5 sm:h-fit flex flex-row gap-12 sm:gap-4 sm:flex-col mr-4 border-e border-zinc-200">
+  <div class="hidden lg:flex h-fit w-full lg:w-1/5 lg:h-fit flex-col mr-4 border-e border-zinc-200">
     <%= unless @advanced_search do %>
       <div>
         <p class="py-2">Date</p>
@@ -470,6 +478,389 @@
       </div>
     <% end %>
   </div>
+
+<!-- Floating Filter Button (Mobile/Tablet only) -->
+<button
+  id="mobile-filter-button"
+  phx-click={
+    JS.add_class("hidden", to: "#mobile-filter-button")
+    |> JS.show(to: "#mobile-filters")
+  }
+  class="lg:hidden fixed bottom-6 right-6 p-4 rounded-full shadow-lg z-50"
+  style="background-color: rgb(231, 109, 103); color: rgb(81, 78, 128);"
+>
+  <!-- filter icon -->
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+      d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L15 13.414V19a1 1 0 01-.447.832l-4 2.5A1 1 0 019 21v-7.586L3.293 6.707A1 1 0 013 6V4z" />
+  </svg>
+</button>
+
+<!-- Mobile Filter Drawer -->
+<div
+  id="mobile-filters"
+  class="lg:hidden hidden fixed inset-0 z-40"
+>
+  <!-- Overlay -->
+  <div
+    class="absolute inset-0 bg-black/50"
+    phx-click={
+      JS.hide(to: "#mobile-filters")
+      |> JS.exec("setTimeout(()=>{ document.getElementById('mobile-filter-button').classList.remove('hidden') }, 200)")
+    }
+    phx-transition-enter="transition-opacity ease-out duration-300"
+    phx-transition-enter-from="opacity-0"
+    phx-transition-enter-to="opacity-100"
+    phx-transition-leave="transition-opacity ease-in duration-200"
+    phx-transition-leave-from="opacity-100"
+    phx-transition-leave-to="opacity-0"
+  >
+  </div>
+
+  <!-- Sliding Drawer -->
+  <div
+    class="absolute bottom-0 left-0 right-0 bg-white rounded-t-2xl p-6 max-h-[80vh] overflow-y-auto shadow-lg"
+    phx-transition-enter="transform transition ease-out duration-300"
+    phx-transition-enter-from="translate-y-full"
+    phx-transition-enter-to="translate-y-0"
+    phx-transition-leave="transform transition ease-in duration-200"
+    phx-transition-leave-from="translate-y-0"
+    phx-transition-leave-to="translate-y-full"
+  >
+    <!-- Header -->
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="text-lg font-semibold">Filter By</h2>
+      <button
+        phx-click={
+          JS.hide(to: "#mobile-filters")
+          |> JS.remove_class("hidden", to: "#mobile-filter-button")
+        }
+        class="text-gray-500 hover:text-gray-800"
+      >
+        ✕
+      </button>
+    </div>
+
+    <!-- 👇 Filters for Mobile (your existing filters) -->
+    <div class="space-y-4">
+      <%= unless @advanced_search do %>
+        <div>
+        <p class="py-2">Date</p>
+        <div id="date-range-selector" phx-hook="DateSelector" class="flex-row gap-2 flex-wrap">
+          <div class="flex flex-row gap-2 text-xs items-center">
+            <label for="from">from&nbsp;&nbsp;</label>
+            <input
+              class="text-xs text-black dark:text-black dark:bg-dark-bg mt-1 mr-1 block w-fit rounded border-gray-200 focus:border-gray-400 dark:border-gray-600"
+              type="date"
+              id="from"
+              name="from"
+              value={Keyword.get(@search_params, :from)}
+              phx-change="change-search"
+              phx-value-name="date-range"
+              phx-value-type="start"
+            />
+          </div>
+          <div class="flex flex-row gap-2 text-xs items-center">
+            <label for="to"> to&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </label>
+            <input
+              class="text-xs text-black dark:text-black dark:bg-dark-bg mt-1 mr-1 block w-fit rounded border-gray-200 focus:border-gray-400 dark:border-gray-600"
+              type="date"
+              id="to"
+              name="to"
+              value={Keyword.get(@search_params, :to)}
+              phx-change="change-search"
+              phx-value-name="date-range"
+              phx-value-type="end"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Level of Severity</p>
+        <div>
+          <.input_radio
+            name="level_of_severity"
+            id="low"
+            value="low"
+            label="Low"
+            selection={Keyword.get(@search_params, :level_of_severity)}
+          />
+          <.input_radio
+            name="level_of_severity"
+            id="medium"
+            value="medium"
+            label="Medium"
+            selection={Keyword.get(@search_params, :level_of_severity)}
+          />
+          <.input_radio
+            name="level_of_severity"
+            id="high"
+            value="high"
+            label="High"
+            selection={Keyword.get(@search_params, :level_of_severity)}
+          />
+          <.input_radio
+            name="level_of_severity"
+            id="all"
+            value="all"
+            label="All"
+            selection={Keyword.get(@search_params, :level_of_severity)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Is Casual?</p>
+        <div>
+          <.input_radio
+            name="casual"
+            id="casual_true"
+            value="true"
+            label="Yes"
+            selection={Keyword.get(@search_params, :casual)}
+          />
+          <.input_radio
+            name="casual"
+            id="casual_false"
+            value="false"
+            label="No"
+            selection={Keyword.get(@search_params, :casual)}
+          />
+          <.input_radio
+            name="casual"
+            id="casual_all"
+            value="all"
+            label="All"
+            selection={Keyword.get(@search_params, :casual)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Is Appropriated?</p>
+        <div>
+          <.input_radio
+            name="appropriated"
+            id="appropriated_true"
+            value="true"
+            label="Yes"
+            selection={Keyword.get(@search_params, :appropriated)}
+          />
+          <.input_radio
+            name="appropriated"
+            id="appropriated_false"
+            value="false"
+            label="No"
+            selection={Keyword.get(@search_params, :appropriated)}
+          />
+          <.input_radio
+            name="appropriated"
+            id="appropriated_all"
+            value="all"
+            label="All"
+            selection={Keyword.get(@search_params, :appropriated)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Source</p>
+        <div>
+          <.input_radio
+            name="source"
+            id="plugin"
+            value="plugin"
+            label="Plugin"
+            selection={Keyword.get(@search_params, :source)}
+          />
+          <.input_radio
+            name="source"
+            id="experts_2022"
+            value="experts_2022"
+            label="Experts 2022"
+            selection={Keyword.get(@search_params, :source)}
+          />
+          <.input_radio
+            name="source"
+            id="crowdsourcing_exercise"
+            value="crowdsourcing_exercise"
+            label="Crowdsourcing Exercise"
+            selection={Keyword.get(@search_params, :source)}
+          />
+          <.input_radio
+            name="source"
+            id="source_all"
+            value="all"
+            label="All"
+            selection={Keyword.get(@search_params, :source)}
+          />
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Categories</p>
+        <div>
+          <.checkbox
+            id="gendered"
+            group="categories"
+            label="Gendered"
+            selection={
+              if "gendered" in Keyword.get(@search_params, :categories, []),
+                do: ["gendered"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="sexualized"
+            group="categories"
+            label="Sexualized"
+            selection={
+              if "sexualized" in Keyword.get(@search_params, :categories, []),
+                do: ["sexualized"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="religion"
+            group="categories"
+            label="Religion"
+            selection={
+              if "religion" in Keyword.get(@search_params, :categories, []),
+                do: ["religion"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="ethnicity"
+            group="categories"
+            label="Ethnicity"
+            selection={
+              if "ethnicity" in Keyword.get(@search_params, :categories, []),
+                do: ["ethnicity"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="political_affiliation"
+            group="categories"
+            label="Political Affiliation"
+            selection={
+              if "political_affiliation" in Keyword.get(@search_params, :categories, []),
+                do: ["political_affiliation"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="caste"
+            group="categories"
+            label="Caste"
+            selection={
+              if "caste" in Keyword.get(@search_params, :categories, []),
+                do: ["caste"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="class"
+            group="categories"
+            label="Class"
+            selection={
+              if "class" in Keyword.get(@search_params, :categories, []),
+                do: ["class"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="body_shaming"
+            group="categories"
+            label="Body Shaming"
+            selection={
+              if "body_shaming" in Keyword.get(@search_params, :categories, []),
+                do: ["body_shaming"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="ableist"
+            group="categories"
+            label="Ableist"
+            selection={
+              if "ableist" in Keyword.get(@search_params, :categories, []),
+                do: ["ableist"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="sexual_identity"
+            group="categories"
+            label="Sexual Identity"
+            selection={
+              if "sexual_identity" in Keyword.get(@search_params, :categories, []),
+                do: ["sexual_identity"],
+                else: [""]
+            }
+          />
+          <.checkbox
+            id="other"
+            group="categories"
+            label="Other"
+            selection={
+              if "other" in Keyword.get(@search_params, :categories, []),
+                do: ["other"],
+                else: [""]
+            }
+          />
+        </div>
+      </div>
+
+      <div>
+        <p class="py-2">Sort</p>
+        <div>
+          <.input_radio
+            name="sort-by"
+            id="newest"
+            value="newest"
+            label="Newest first"
+            selection={Keyword.get(@search_params, :sort)}
+          />
+          <.input_radio
+            name="sort-by"
+            id="oldest"
+            value="oldest"
+            label="Oldest first"
+            selection={Keyword.get(@search_params, :sort)}
+          />
+        </div>
+      </div>
+      <% end %>
+    </div>
+
+    <!-- Apply / Clear -->
+    <div class="flex justify-between mt-6">
+      <!-- Clear Filters behaves like desktop Clear All -->
+      <.link
+        href={
+          ~p"/crowdsource-contributions?page_num=1&sort=newest&level_of_severity=all&casual=all&appropriated=all&source=all"
+        }
+        class="px-4 py-2 rounded-lg bg-gray-200 text-center"
+      >
+        Clear Filters
+      </.link>
+
+      <button
+        phx-click={
+        JS.hide(to: "#mobile-filters")
+        |> JS.remove_class("hidden", to: "#mobile-filter-button")
+        }
+        class="px-4 py-2 rounded-lg"
+        style="background-color: rgb(231, 109, 103); color: rgb(81, 78, 128);"
+        >
+        Apply
+      </button>
+    </div>
+  </div>
+</div>
 
   <div class="w-full sm:w-4/5 gap-4">
     <%= unless @advanced_search do %>


### PR DESCRIPTION
### **PR Description**

### Summary
This pull request improves the responsiveness of the Crowdsource Contributions page, ensuring a smoother experience on smaller screens such as mobile devices and tablets.

### Changes Made 
1.**Search Bar**

- Made search bar responsive.
- Now takes full width on small screens and a fixed width on medium+ screens.

2. **"Showing all contributions" header**

- Adjusted heading styles to be responsive (`text-base sm:text-lg md:text-xl`).
- Ensures proper alignment in both mobile and desktop layouts.

3. **Sidebar (Filters section)**

- Sidebar filters (`left-side`) are now hidden on small screens (`hidden lg:flex`).
- Remain visible only on larger screens for better layout.

4. **Clear Filters button**

- Updated visibility: shown only on medium+ screens (`hidden md:inline-flex`).

5. **Mobile/Tablet Filter Drawer**

- Added a floating button (`#mobile-filter-button`) for mobile and tablet users.
- On click, a sliding drawer opens from the right side with all filters.
- Drawer includes an overlay and smooth transition animations.

### Before

- Filters sidebar always visible, making layout cramped.
- Search bar and headers were not scaling properly.

### After

- Sidebar hidden on small screens, replaced by floating filter button + drawer.
- Search bar and contribution header align properly on all screen sizes.

### Help Needed
Currently, the mobile filter drawer **automatically applies** filters as soon as the user selects them.
I would like to change this behavior so that filters are only applied **after the user clicks an "Apply" button** inside the drawer.

If anyone can guide me on how to prevent auto-apply on selection and instead apply filters only on explicit button click, that would be very helpful.

### Screenshots
<img width="428" height="817" alt="image" src="https://github.com/user-attachments/assets/7505c3e2-38ba-454a-9b62-f091a70e7517" />

<img width="429" height="818" alt="image" src="https://github.com/user-attachments/assets/ab7413a6-c357-4270-963f-e9ccf160c47e" />



